### PR TITLE
[bug] changed inconsolata reference as it seems to be registered as all small characters

### DIFF
--- a/mintscript.py
+++ b/mintscript.py
@@ -235,8 +235,8 @@ def latexoptions(args):
         dict: holds LaTeX packages options
     '''
     ret = {'input':args.file, 'geometry':['xetex'], 'minted':[], 'mintedlang':'text'
-          ,'mintedstyle':'autumn', 'font':('Inconsolata','8pt'), 'multicols':None
-          ,'header_font':('Inconsolata','8pt'), 'header':None, 'footer':None
+          ,'mintedstyle':'autumn', 'font':('inconsolata','8pt'), 'multicols':None
+          ,'header_font':('inconsolata','8pt'), 'header':None, 'footer':None
           ,'fontspec_args':['AutoFakeSlant','AutoFakeBold']}
     if args.columns==1:
         ret['geometry'].append('onecolumn')


### PR DESCRIPTION
Debian 9

error message otherwise:

```
kpathsea: Running mktextfm Inconsolata
/usr/share/texlive/texmf-dist/web2c/mktexnam: Could not map source abbreviation I for Inconsolata.
/usr/share/texlive/texmf-dist/web2c/mktexnam: Need to update /usr/share/texlive/texmf-dist/fonts/map/fontname/special.map?
mktextfm: Running mf-nowin -progname=mf \mode:=ljfour; mag:=1; nonstopmode; input Inconsolata
This is METAFONT, Version 2.7182818 (TeX Live 2016/Debian) (preloaded base=mf)


kpathsea: Running mktexmf Inconsolata
! I can't find file `Inconsolata'.
<*> ...our; mag:=1; nonstopmode; input Inconsolata
                                                  
Please type another input file name
! Emergency stop.
<*> ...our; mag:=1; nonstopmode; input Inconsolata
                                                  
Transcript written on mfput.log.
grep: Inconsolata.log: No such file or directory
mktextfm: `mf-nowin -progname=mf \mode:=ljfour; mag:=1; nonstopmode; input Inconsolata' failed to make Inconsolata.tfm.
kpathsea: Appending font creation commands to missfont.log.


!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!
! fontspec error: "font-not-found"
! 
! The font "Inconsolata" cannot be found.
! 
! See the fontspec documentation for further information.
! 
! For immediate help type H <return>.
!...............................................  
```